### PR TITLE
Declare previously dynamic variables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["symfony", "propel", "orm", "active record", "mapping", "database", "persistence"],
     "homepage": "http://www.propelorm.org/",
     "require": {
-        "composer/installers": "^v1.12.0",
+        "friendsofsymfony1/symfony1-installer-plugin": "^1.0",
         "propel/propel1": "~1.6"
     },
     "extra": {

--- a/lib/form/sfFormPropel.class.php
+++ b/lib/form/sfFormPropel.class.php
@@ -122,7 +122,7 @@ abstract class sfFormPropel extends sfFormObject
    * @param array $taintedValues  An array of input values
    * @param array $taintedFiles   An array of uploaded files (in the $_FILES or $_GET format)
    */
-  public function bind(array $taintedValues = null, array $taintedFiles = null)
+  public function bind(?array $taintedValues = null, ?array $taintedFiles = null)
   {
     $this->addOptionalForms($taintedValues);
     return parent::bind($taintedValues, $taintedFiles);
@@ -466,7 +466,7 @@ abstract class sfFormPropel extends sfFormObject
    *
    * @return string The filename used to save the file
    */
-  protected function saveFile($field, $filename = null, sfValidatedFile $file = null)
+  protected function saveFile($field, $filename = null, ?sfValidatedFile $file = null)
   {
     if (!$this->validatorSchema[$field] instanceof sfValidatorFile)
     {

--- a/lib/generator/sfPropelFormGenerator.class.php
+++ b/lib/generator/sfPropelFormGenerator.class.php
@@ -23,6 +23,12 @@ class sfPropelFormGenerator extends sfGenerator
   protected
     $dbMap = null;
 
+  public
+    $params = null;
+
+  public
+    $table = null;
+
   /**
    * Initializes the current sfGenerator instance.
    *

--- a/lib/log/sfPropelLogger.class.php
+++ b/lib/log/sfPropelLogger.class.php
@@ -26,7 +26,7 @@ class sfPropelLogger implements BasicLogger
    *
    * @param sfEventDispatcher $dispatcher
    */
-  public function __construct(sfEventDispatcher $dispatcher = null)
+  public function __construct(?sfEventDispatcher $dispatcher = null)
   {
     if (null === $dispatcher)
     {

--- a/lib/task/sfPropelGenerateModuleTask.class.php
+++ b/lib/task/sfPropelGenerateModuleTask.class.php
@@ -20,6 +20,8 @@ require_once(dirname(__FILE__).'/sfPropelBaseTask.class.php');
  */
 class sfPropelGenerateModuleTask extends sfPropelBaseTask
 {
+  protected $constants;
+
   /**
    * @see sfTask
    */


### PR DESCRIPTION
Avoid warning about dynamic variables in php8.2.